### PR TITLE
929. Unique Email Addresses

### DIFF
--- a/929. Unique Email Addresses.md
+++ b/929. Unique Email Addresses.md
@@ -1,3 +1,5 @@
+929. Unique Email Addresses
+
 Every valid email consists of a local name and a domain name, separated by the '@' sign. Besides lowercase letters, the email may contain one or more '.' or '+'.
 
 For example, in "alice@leetcode.com", "alice" is the local name, and "leetcode.com" is the domain name.
@@ -12,3 +14,121 @@ It is possible to use both of these rules at the same time.
 Given an array of strings emails where we send one email to each emails[i], return the number of different addresses that actually receive mails.
 
 url:https://leetcode.com/problems/unique-email-addresses/description/
+
+Example 1:
+
+Input: emails = ["test.email+alex@leetcode.com","test.e.mail+bob.cathy@leetcode.com","testemail+david@lee.tcode.com"]
+Output: 2
+Explanation: "testemail@leetcode.com" and "testemail@lee.tcode.com" actually receive mails.
+Example 2:
+
+Input: emails = ["a@leetcode.com","b@leetcode.com","c@leetcode.com"]
+Output: 3
+ 
+
+Constraints:
+
+1 <= emails.length <= 100
+1 <= emails[i].length <= 100
+emails[i] consist of lowercase English letters, '+', '.' and '@'.
+Each emails[i] contains exactly one '@' character.
+All local and domain names are non-empty.
+Local names do not start with a '+' character.
+Domain names end with the ".com" suffix.
+Domain names must contain at least one character before ".com" suffix.
+
+---
+
+step1 一発クリア
+```py
+class Solution:
+    def numUniqueEmails(self, emails: List[str]) -> int:
+        if not emails:
+            return []
+
+        result_set = set()
+
+        for email in emails:
+            splited_email = email.split("@")
+
+            if "+" in splited_email[0]:
+                splited_email[0] = splited_email[0].split("+")[0]
+            if "." in splited_email[0]:
+                splited_email[0] = splited_email[0].replace(".", "")
+            
+            joined_email = "@".join(splited_email)
+            result_set.add(joined_email)
+        return len(result_set)
+
+"""
+以下をlen(emails)回ループする
+1.@の左側をsplitで得る
+2.もしも+があれば+の右側をsplitで捨てる
+3.もしも.があれば.はreplaceで捨てる
+4.1でわけた右側と3でできた左側を"@"を区切り文字にしてjoinで繋げる
+5.set集合にaddする。
+"""
+```
+先に日本語で手順をまとめてから、コーディングするようにした。  
+emails.lengthをnとする。emailsの中の文字列の長さをkとする。  
+時間計算量: for文で回すのでO(n)、splitやreplace,joinは文字列を全て走査するのでO(k)、addはハッシュ走査なのでO(1)、よって時間計算量はO(n * k)。  
+空間計算量: splitやreplace、joinは引数にとった文字列分のメモリを確保して、リストや文字列を吐き出すのでO(k)。それをfor文で回しているのでO(n * k)。ハッシュは定数項なので無視する。  
+nもkも上限が10^2なので、時間計算量は最悪10^4。結構余裕がある。splitやreplace,joinは非破壊的なので引数のemailsのリストの中身も破壊されないし、いいかも。  
+
+---
+(https://github.com/olsen-blue/Arai60/pull/14)  
+(https://github.com/aki235/Arai60/pull/14)  
+コーディング練習会典型コメント集の該当部分  
+を読んだ。  
+
+rsplitをなんで使うのか気になったけど、ローカルの部分に"@"が入る場合を懸念して、右から区切るようにしたのか。  
+step1で書いたコードで良さそうな気はするが、正規表現を学ぶためにそっちでstep2かいてもいいかも。  
+
+step2
+```py
+class Solution:
+    def numUniqueEmails(self, emails: List[str]) -> int:
+        normalized_set = set()
+        if not emails:
+            return []
+
+        for email in emails:
+            if not "@" in email:
+                raise ValueError("An email must contain '@'.")
+            local_name, domain_name = email.rsplit("@", 1)
+
+            plus_ignored_local_name = re.sub(r"\+.*", "", local_name)
+            dot_removed_local_name = re.sub(r"\.", "", plus_ignored_local_name)
+
+            normalized_set.add(f"{dot_removed_local_name}@{domain_name}")
+        
+        return len(normalized_set)
+```
+時間計算量: for文回すのでO(n)、正規表現で文字列を走査するのでO(k)、よって全体でO(n * k)  
+空間計算量: 正規表現やrsplitで文字列分のメモリを確保するのでO(k)、それをfor文で回すのでO(n * k)  
+
+---
+step3 3回連続pass
+```py
+class Solution:
+    def numUniqueEmails(self, emails: List[str]) -> int:
+        normalized_set = set()
+        if not emails:
+            return []
+
+        for email in emails:
+            if not "@" in email:
+                raise ValueError("An email must contain '@'.")
+            local_name, domain_name = email.rsplit("@", 1)
+
+            plus_ignored_local_name = re.sub(r"\+.*", "", local_name)
+            dot_removed_local_name = re.sub(r"\.", "", plus_ignored_local_name)
+
+            normalized_set.add(f"{dot_removed_local_name}@{domain_name}")
+        
+        return len(normalized_set)
+```
+正規表現を使う時RoDoSという攻撃に注意しないといけない。(https://qiita.com/flat-field/items/f5b0c803ba0b7030d97a)  
+今回は文字列の上限が決まっていたが、指定されていなかったら、if len(email) > MAX_LENGTH_EMAIL: raise ValueErrorなどでガードを入れたほうがいいかも。  
+
+

--- a/929. Unique Email Addresses.md
+++ b/929. Unique Email Addresses.md
@@ -1,0 +1,14 @@
+Every valid email consists of a local name and a domain name, separated by the '@' sign. Besides lowercase letters, the email may contain one or more '.' or '+'.
+
+For example, in "alice@leetcode.com", "alice" is the local name, and "leetcode.com" is the domain name.
+If you add periods '.' between some characters in the local name part of an email address, mail sent there will be forwarded to the same address without dots in the local name. Note that this rule does not apply to domain names.
+
+For example, "alice.z@leetcode.com" and "alicez@leetcode.com" forward to the same email address.
+If you add a plus '+' in the local name, everything after the first plus sign will be ignored. This allows certain emails to be filtered. Note that this rule does not apply to domain names.
+
+For example, "m.y+name@email.com" will be forwarded to "my@email.com".
+It is possible to use both of these rules at the same time.
+
+Given an array of strings emails where we send one email to each emails[i], return the number of different addresses that actually receive mails.
+
+url:https://leetcode.com/problems/unique-email-addresses/description/


### PR DESCRIPTION
Every valid email consists of a local name and a domain name, separated by the '@' sign. Besides lowercase letters, the email may contain one or more '.' or '+'.

For example, in "alice@leetcode.com", "alice" is the local name, and "leetcode.com" is the domain name.
If you add periods '.' between some characters in the local name part of an email address, mail sent there will be forwarded to the same address without dots in the local name. Note that this rule does not apply to domain names.

For example, "alice.z@leetcode.com" and "alicez@leetcode.com" forward to the same email address.
If you add a plus '+' in the local name, everything after the first plus sign will be ignored. This allows certain emails to be filtered. Note that this rule does not apply to domain names.

For example, "m.y+name@email.com" will be forwarded to "my@email.com".
It is possible to use both of these rules at the same time.

Given an array of strings emails where we send one email to each emails[i], return the number of different addresses that actually receive mails.

url: https://leetcode.com/problems/unique-email-addresses/description/